### PR TITLE
update system-upgrade to repo root kustomziation

### DIFF
--- a/cluster/core/system-upgrade/kustomization.yaml
+++ b/cluster/core/system-upgrade/kustomization.yaml
@@ -1,5 +1,8 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: system-upgrade
 resources:
-  - https://github.com/rancher/system-upgrade-controller/releases/download/v0.6.2/system-upgrade-controller.yaml
+  - github.com/rancher/system-upgrade-controller?ref=v0.7.3
+images:
+  - name: rancher/system-upgrade-controller
+    newTag: v0.7.3


### PR DESCRIPTION
**Description of the change**

Updates the system-upgrade-controller kustomization to pull from the source repo's root kustomization.yaml instead of the release yaml. Also brings system-upgrade-controller up to v0.7.3

**Benefits**

This allows renovate bot to update the controller automatically.
