### PR TITLE
fix: remove duplicate secret definition, update kustomization.yaml

### DIFF
--- a/cluster/core/cert-manager/kustomization.yaml
+++ b/cluster/core/cert-manager/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - helm-release.yaml
   - letsencrypt-production.yaml
   - letsencrypt-staging.yaml
-  - secret.enc.yaml
+  - secret.sops.yaml

--- a/cluster/core/cert-manager/secret.enc.yaml
+++ b/cluster/core/cert-manager/secret.enc.yaml
@@ -1,8 +1,0 @@
-# yamllint disable
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cloudflare-token-secret
-  namespace: cert-manager
-stringData:
-  cloudflare-token: ${BOOTSTRAP_CLOUDFLARE_TOKEN}


### PR DESCRIPTION
**Description of the change**

I was following the README instructions and run into a problem where flux would fail because of a `cloudflare-token-secret` secret that was created without the data set. My understanding is that `secret.enc.yaml` was renamed to`secret.sops.yaml`, but not every configuration was updated accordingly. 

