### PR TITLE
Allow ExternalName services

### DIFF
--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -54,6 +54,7 @@ spec:
     additionalArguments:
       - "--providers.kubernetesingress.ingressendpoint.ip=${SVC_TRAEFIK_ADDR}"
       - "--providers.kubernetescrd.allowexternalnameservices=true"
+      - "--providers.kubernetesingress.allowexternalnameservices=true"
     ports:
       traefik:
         expose: true


### PR DESCRIPTION
**Description of the change**

This option allows the use of service type `ExternalName`:
https://kubernetes.io/docs/concepts/services-networking/service/#externalname

**Benefits**

One can create `ExternalName` service
