### PR TITLE
Use global substring substitution for tls secret

### DIFF
--- a/cluster/apps/default/hajimari/helm-release.yaml
+++ b/cluster/apps/default/hajimari/helm-release.yaml
@@ -113,7 +113,7 @@ spec:
         tls:
           - hosts:
               - "hajimari.${SECRET_DOMAIN}"
-            secretName: "hajimari-${SECRET_DOMAIN/./-}-tls"
+            secretName: "hajimari-${SECRET_DOMAIN//./-}-tls"
     persistence:
       data:
         enabled: true

--- a/cluster/apps/networking/traefik/dashboard/ingress.yaml
+++ b/cluster/apps/networking/traefik/dashboard/ingress.yaml
@@ -15,7 +15,7 @@ spec:
   tls:
     - hosts:
         - "traefik.${SECRET_DOMAIN}"
-      secretName: "traefik-dashboard-${SECRET_DOMAIN/./-}-tls"
+      secretName: "traefik-dashboard-${SECRET_DOMAIN//./-}-tls"
   rules:
     - host: "traefik.${SECRET_DOMAIN}"
       http:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
PR switches go global substring replacement for domain in TLS secret name.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Allows use of subdomains in SECRET DOMAIN. For example, my cluster uses a domain like `subdomain.domain.tld`.
Prior to this fix, secrets were created with format:
`subdomain-domain.tld-tls`

After this fix, secrets created are of form:
`subdomain-domain-tld-tls`

See "Substring Replacement" in these docs as a reference
https://tldp.org/LDP/abs/html/string-manipulation.html 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
May break existing deployments? Not sure.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
