### PR TITLE
feat: move kubeconfig to provision folder during ansible k3s-install

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
 #shellcheck disable=SC2148,SC2155
-export KUBECONFIG=$(expand_path ./kubeconfig)
+export KUBECONFIG=$(expand_path ./provision/kubeconfig)
 export ANSIBLE_CONFIG=$(expand_path ./ansible.cfg)
 export GPG_TTY=$(tty)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 
 ### :sailboat:&nbsp; Installing k3s with Ansible
 
-:round_pushpin: Here we will be running a Ansible Playbook to install [k3s](https://k3s.io/) with [this](https://galaxy.ansible.com/xanmanning/k3s) wonderful k3s Ansible galaxy role. After completion, Ansible will drop a `kubeconfig` in `/tmp/kubeconfig` for use with interacting with your cluster with `kubectl`. This file should be manually copied to the root of your repository.
+:round_pushpin: Here we will be running a Ansible Playbook to install [k3s](https://k3s.io/) with [this](https://galaxy.ansible.com/xanmanning/k3s) wonderful k3s Ansible galaxy role. After completion, Ansible will drop a `kubeconfig` in `./provision/kubeconfig` for use with interacting with your cluster with `kubectl`.
 
 1. Verify Ansible can view your config by running `task ansible:list`
 
@@ -217,9 +217,7 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 
 4. If everything goes as planned you should see Ansible running the k3s install Playbook against your nodes.
 
-5. Copy the `kubeconfig` file from `/tmp` to your repository.
-
-6. Verify the nodes are online
+5. Verify the nodes are online
    
 ```sh
 kubectl --kubeconfig=./kubeconfig get nodes

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 5. Verify the nodes are online
    
 ```sh
-kubectl --kubeconfig=./kubeconfig get nodes
+kubectl --kubeconfig=./provision/kubeconfig get nodes
 # NAME           STATUS   ROLES                       AGE     VERSION
 # k8s-0          Ready    control-plane,master      4d20h   v1.21.5+k3s1
 # k8s-1          Ready    worker                    4d20h   v1.21.5+k3s1
@@ -233,7 +233,7 @@ kubectl --kubeconfig=./kubeconfig get nodes
 1. Verify Flux can be installed
 
 ```sh
-flux --kubeconfig=./kubeconfig check --pre
+flux --kubeconfig=./provision/kubeconfig check --pre
 # ► checking prerequisites
 # ✔ kubectl 1.21.5 >=1.18.0-0
 # ✔ Kubernetes 1.21.5+k3s1 >=1.16.0-0
@@ -243,7 +243,7 @@ flux --kubeconfig=./kubeconfig check --pre
 2. Pre-create the `flux-system` namespace
 
 ```sh
-kubectl --kubeconfig=./kubeconfig create namespace flux-system --dry-run=client -o yaml | kubectl --kubeconfig=./kubeconfig apply -f -
+kubectl --kubeconfig=./provision/kubeconfig create namespace flux-system --dry-run=client -o yaml | kubectl --kubeconfig=./provision/kubeconfig apply -f -
 ```
 
 3. Add the Flux GPG key in-order for Flux to decrypt SOPS secrets
@@ -251,7 +251,7 @@ kubectl --kubeconfig=./kubeconfig create namespace flux-system --dry-run=client 
 ```sh
 source .config.env
 gpg --export-secret-keys --armor "${BOOTSTRAP_FLUX_KEY_FP}" |
-kubectl --kubeconfig=./kubeconfig create secret generic sops-gpg \
+kubectl --kubeconfig=./provision/kubeconfig create secret generic sops-gpg \
     --namespace=flux-system \
     --from-file=sops.asc=/dev/stdin
 ```
@@ -275,7 +275,7 @@ git push
 :round_pushpin: Due to race conditions with the Flux CRDs you will have to run the below command twice. There should be no errors on this second run.
 
 ```sh
-kubectl --kubeconfig=./kubeconfig apply --kustomize=./cluster/base/flux-system
+kubectl --kubeconfig=./provision/kubeconfig apply --kustomize=./cluster/base/flux-system
 # namespace/flux-system configured
 # customresourcedefinition.apiextensions.k8s.io/alerts.notification.toolkit.fluxcd.io created
 # ...
@@ -290,7 +290,7 @@ kubectl --kubeconfig=./kubeconfig apply --kustomize=./cluster/base/flux-system
 8. Verify Flux components are running in the cluster
 
 ```sh
-kubectl --kubeconfig=./kubeconfig get pods -n flux-system
+kubectl --kubeconfig=./provision/kubeconfig get pods -n flux-system
 # NAME                                       READY   STATUS    RESTARTS   AGE
 # helm-controller-5bbd94c75-89sb4            1/1     Running   0          1h
 # kustomize-controller-7b67b6b77d-nqc67      1/1     Running   0          1h

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
   TERRAFORM_DIR: "{{.PROJECT_DIR}}/provision/terraform"
 
 env:
-  KUBECONFIG: "{{.PROJECT_DIR}}/kubeconfig"
+  KUBECONFIG: "{{.PROJECT_DIR}}/provision/kubeconfig"
 
 includes:
   ansible: .taskfiles/ansible.yml

--- a/provision/ansible/playbooks/k3s-install.yml
+++ b/provision/ansible/playbooks/k3s-install.yml
@@ -27,11 +27,18 @@
         name: xanmanning.k3s
         public: true
 
-    - name: Copy kubeconfig locally to /tmp
+    - name: Get absolute path to this Git repository
+      delegate_to: localhost
+      become: false
+      run_once: true
+      ansible.builtin.command: "git rev-parse --show-toplevel"
+      register: repo_abs_path
+
+    - name: Copy kubeconfig to provision folder
       run_once: true
       ansible.builtin.fetch:
         src: "/etc/rancher/k3s/k3s.yaml"
-        dest: "/tmp/kubeconfig"
+        dest: "{{ repo_abs_path.stdout }}/provision/kubeconfig"
         flat: true
       when:
         - k3s_control_node is defined
@@ -42,7 +49,7 @@
       become: false
       run_once: true
       ansible.builtin.replace:
-        path: "/tmp/kubeconfig"
+        path: "{{ repo_abs_path.stdout }}/provision/kubeconfig"
         regexp: "https://127.0.0.1:6443"
         replace: "https://{{ k3s_registration_address }}:6443"
 


### PR DESCRIPTION
Signed-off-by: Devin Buhl <devin.kray@gmail.com>

**Description of the change**

Places the kubeconfig into the provision dir

**Benefits**

Buck is not confused

**Possible drawbacks**

`whereis kubeconfig`

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
