### PR TITLE
Fix pre-commit yammlint errors during setup

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -108,7 +108,7 @@ _has_envar() {
 _has_valid_ip() {
     local ip="${1}"
     local variable_name="${2}"
-    
+
     if ! ipcalc "${ip}" | awk 'BEGIN{FS=":"; is_invalid=0} /^INVALID/ {is_invalid=1; print $1} END{exit is_invalid}' >/dev/null 2>&1; then
         _log "INFO" "Variable '${variable_name}' has an invalid IP address '${ip}'"
         exit 1
@@ -123,14 +123,14 @@ verify_gpg() {
 
     if ! gpg --list-keys "${BOOTSTRAP_PERSONAL_KEY_FP}" >/dev/null 2>&1; then
          _log "ERROR" "Invalid Personal GPG FP ${BOOTSTRAP_PERSONAL_KEY_FP}"
-        exit 1    
+        exit 1
     else
         _log "INFO" "Found Personal GPG Fingerprint '${BOOTSTRAP_PERSONAL_KEY_FP}'"
     fi
 
     if ! gpg --list-keys "${BOOTSTRAP_FLUX_KEY_FP}" >/dev/null 2>&1; then
          _log "ERROR" "Invalid Flux GPG FP '${BOOTSTRAP_FLUX_KEY_FP}'"
-        exit 1    
+        exit 1
     else
          _log "INFO" "Found Flux GPG Fingerprint '${BOOTSTRAP_FLUX_KEY_FP}'"
     fi
@@ -260,6 +260,7 @@ generate_ansible_host_secrets() {
 generate_ansible_hosts() {
     local worker_node_count=
     {
+        printf -- "---\n"
         printf "kubernetes:\n"
         printf "  children:\n"
         printf "    master:\n"

--- a/tmpl/cluster/kube-vip-daemonset.yaml
+++ b/tmpl/cluster/kube-vip-daemonset.yaml
@@ -44,9 +44,9 @@ spec:
           securityContext:
             capabilities:
               add:
-              - NET_ADMIN
-              - NET_RAW
-              - SYS_TIME
+                - NET_ADMIN
+                - NET_RAW
+                - SYS_TIME
       hostAliases:
         - hostnames:
             - kubernetes


### PR DESCRIPTION
**Description of the change**

After following the setup guide and running `./configure.sh`, I encountered two pre-commit yamllint errors when trying to commit the generated files:

```sh
$ git commit
yamllint....................................................................Failed
- hook id: yamllint
- exit code: 1

cluster/core/kube-system/kube-vip/daemon-set.yaml
  47:15     error    wrong indentation: expected 16 but found 14  (indentation)

provision/ansible/inventory/hosts.yml
  1:1       warning  missing document start "---"  (document-start)
```

**Benefits**

Easier setup, less problems for first time users.

**Possible drawbacks**

No drawbacks.

However, considering you can define list elements in yaml with and without indentation:

```sh
list:
- a
- b
```

vs.
```sh
list:
  - a
  - b
```
... one could argue that the current indentation rule at https://github.com/k8s-at-home/template-cluster-k3s/blob/main/.github/lint/.yamllint.yaml#L17 should be replaced with:

```sh
  indentation:
    spaces: 2
    indent-sequences: whatever
```


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


**Additional information**

