### PR TITLE
fix: add ansible.posix collection to requirements

### DIFF
--- a/provision/ansible/requirements.yml
+++ b/provision/ansible/requirements.yml
@@ -4,6 +4,8 @@ collections:
     version: 4.0.0
   - name: community.sops
     version: 1.1.0
+  - name: ansible.posix
+    version: 1.3.0
 roles:
   - src: xanmanning.k3s
     version: v2.11.1


### PR DESCRIPTION
**Description of the change**

Added ansible.posix collection to the ansible requirements file. The ubuntu-prepare playbook was crashing on the filesystem task due to the missing collection, required to create the max user watches sysctl config file.