### PR TITLE
match system-upgrade channels to deployed k3s ver

### DIFF
--- a/cluster/apps/system-upgrade/system-upgrade-controller/agent-plan.yaml
+++ b/cluster/apps/system-upgrade/system-upgrade-controller/agent-plan.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   serviceAccountName: system-upgrade
   concurrency: 1
-  channel: https://update.k3s.io/v1-release/channels/v1.21
+  channel: https://update.k3s.io/v1-release/channels/v1.22
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/master

--- a/cluster/apps/system-upgrade/system-upgrade-controller/server-plan.yaml
+++ b/cluster/apps/system-upgrade/system-upgrade-controller/server-plan.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceAccountName: system-upgrade
   concurrency: 1
-  channel: https://update.k3s.io/v1-release/channels/v1.21
+  channel: https://update.k3s.io/v1-release/channels/v1.22
   cordon: true
   nodeSelector:
     matchExpressions:


### PR DESCRIPTION
**Description of the change**

Currently the ansible k3s role installs version v1.22.3+k3s1, but the system-upgrade controller is using the v1.21 channels.
This causes downgrade problems.

**Benefits**

Version matches 

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none