### PR TITLE
fix age-secret namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ kubectl --kubeconfig=./provision/kubeconfig create namespace flux-system --dry-r
 
 ```sh
 cat ~/.config/sops/age/keys.txt |
-    kubectl -n default create secret generic sops-age \
+    kubectl -n flux-system create secret generic sops-age \
     --from-file=age.agekey=/dev/stdin
 ```
 


### PR DESCRIPTION
**Description of the change**

age-secret is not needed in the "default" namespace. This secret is needed in the "flux-system" namespace.

**Benefits**

secret can be used correctly 

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none