### PR TITLE
fix(readme.md): Add ./provision/kubeconfig to sops/flux setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ kubectl --kubeconfig=./provision/kubeconfig create namespace flux-system --dry-r
 
 ```sh
 cat ~/.config/sops/age/keys.txt |
-    kubectl -n flux-system create secret generic sops-age \
+    kubectl --kubeconfig=./provision/kubeconfig \
+    -n flux-system create secret generic sops-age \
     --from-file=age.agekey=/dev/stdin
 ```
 


### PR DESCRIPTION
**Description of the change**

Add `--kubeconfig=./provision/kubeconfig` option to sops/flux integration command.

**Benefits**

Return code 0!

**Possible drawbacks**

None that I know.

**Applicable issues**
