### PR TITLE
kube-vip: Drop SYS_TIME capability

### DIFF
--- a/provision/ansible/playbooks/templates/kube-vip-daemonset.yaml.j2
+++ b/provision/ansible/playbooks/templates/kube-vip-daemonset.yaml.j2
@@ -46,7 +46,6 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_RAW
-                - SYS_TIME
       hostAliases:
         - hostnames:
             - kubernetes

--- a/tmpl/cluster/kube-vip-daemonset.yaml
+++ b/tmpl/cluster/kube-vip-daemonset.yaml
@@ -46,7 +46,6 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_RAW
-                - SYS_TIME
       hostAliases:
         - hostnames:
             - kubernetes


### PR DESCRIPTION


**Description of the change**

Drops SYS_TIME capability
**Benefits**

Less permissions for the container to manipulate the host

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

Dropped upstream in https://github.com/kube-vip/kube-vip/pull/336