### PR TITLE
chore: fix typo regarding sops files in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ cat ~/.config/sops/age/keys.txt |
     --from-file=age.agekey=/dev/stdin
 ```
 
-:round_pushpin: Variables defined in `./cluster/base/cluster-secrets.sops.yaml` and `./cluster/base/cluster-settings.sops.yaml` will be usable anywhere in your YAML manifests under `./cluster`
+:round_pushpin: Variables defined in `./cluster/base/cluster-secrets.sops.yaml` and `./cluster/base/cluster-settings.yaml` will be usable anywhere in your YAML manifests under `./cluster`
 
-4. **Verify** all the above files are **encrypted** with SOPS
+4. **Verify** the `./cluster/base/cluster-secrets.sops.yaml` and `./cluster/core/cert-manager/secret.sops.yaml` files are **encrypted** with SOPS
 
 5. If you verified all the secrets are encrypted, you can delete the `tmpl` directory now
 


### PR DESCRIPTION
**Description of the change**

This PR updates the readme to fix the README typo regarding which files are encrypted by SOPS.

**Benefits**

Clearer README instructions

**Possible drawbacks**

None, if the README correction is accurate

**Applicable issues**

- fixes: https://github.com/k8s-at-home/template-cluster-k3s/issues/176#issuecomment-1002817502

**Additional information**

New to this repo so hope I got the fix right 😄 
