### PR TITLE
WIP: add specific packages for raspberry pi on Ubuntu 21.01

### DIFF
--- a/provision/ansible/roles/ubuntu/tasks/packages.yml
+++ b/provision/ansible/roles/ubuntu/tasks/packages.yml
@@ -42,7 +42,7 @@
   ignore_errors: true
   register: is_raspberry 
 
-- name: Install raspberry specific packages
+- name: Install raspberry specific packages for Ubuntu 21 or greater
   ansible.builtin.apt:
     name:
       - linux-modules-extra-raspi
@@ -54,7 +54,7 @@
   register: apt_install_raspberry
   retries: 5
   until: apt_install_raspberry is success
-  when: is_raspberry
+  when: is_raspberry and (ansible_lsb.major_release|int >= 21)
   
 - name: Copy 20auto-upgrades unattended-upgrades config
   ansible.builtin.blockinfile:

--- a/provision/ansible/roles/ubuntu/tasks/packages.yml
+++ b/provision/ansible/roles/ubuntu/tasks/packages.yml
@@ -37,6 +37,25 @@
   retries: 5
   until: apt_install_common is success
 
+- name: check if Raspberry Pi
+  command: grep -q  "Raspberry Pi" /proc/cpuinfo
+  ignore_errors: True
+  register: is_raspberry 
+
+- name: Install raspberry specific packages
+  ansible.builtin.apt:
+    name:
+      - linux-modules-extra-raspi
+    install_recommends: false
+    update_cache: true
+    cache_valid_time: 3600
+    autoclean: true
+    autoremove: true
+  register: apt_install_raspberry
+  retries: 5
+  until: apt_install_raspberry is success
+  when: is_raspberry
+  
 - name: Copy 20auto-upgrades unattended-upgrades config
   ansible.builtin.blockinfile:
     path: /etc/apt/apt.conf.d/20auto-upgrades

--- a/provision/ansible/roles/ubuntu/tasks/packages.yml
+++ b/provision/ansible/roles/ubuntu/tasks/packages.yml
@@ -37,9 +37,9 @@
   retries: 5
   until: apt_install_common is success
 
-- name: check if Raspberry Pi
+- name: Check if Raspberry Pi
   command: grep -q  "Raspberry Pi" /proc/cpuinfo
-  ignore_errors: True
+  ignore_errors: true
   register: is_raspberry 
 
 - name: Install raspberry specific packages


### PR DESCRIPTION
**Description of the change**

Add two tasks to determine if the role is running on a raspberry pi and install raspi specific packages.
Currently only package linux-modules-extra-raspi

**Benefits**

Calico pods will start successfully. Without the package the pods had periodic sigvaults every 30 secs. All other pods coulnt be deployed

**Possible drawbacks**

Only tested on raspi 4



