### PR TITLE
ansible/templates: Bump to kube-vip 0.4.2

### DIFF
--- a/provision/ansible/playbooks/templates/kube-vip-daemonset.yaml.j2
+++ b/provision/ansible/playbooks/templates/kube-vip-daemonset.yaml.j2
@@ -30,7 +30,7 @@ spec:
                 operator: Exists
       containers:
         - name: kube-vip
-          image: ghcr.io/kube-vip/kube-vip:v0.4.1
+          image: ghcr.io/kube-vip/kube-vip:v0.4.2
           imagePullPolicy: IfNotPresent
           args:
             - manager


### PR DESCRIPTION
**Description of the change**
Bump to kube-vip 0.4.2 in ansible playbooks to keep in sync with what's deployed later through flux.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
