### PR TITLE
fix: Update kube-vip on ansible template as well

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,8 @@
   },
   "kubernetes": {
     "fileMatch": [
-      "cluster/.+\\.ya?ml$"
+      "cluster/.+\\.ya?ml$",
+      "provision/ansible/playbooks/templates/.+\\.ya?ml.j2$"
     ]
   },
   "regexManagers": [


### PR DESCRIPTION
Looks like https://github.com/k8s-at-home/template-cluster-k3s/pull/272 doesn't include the ansible template. Hopefully this change will help updating this one as well.