### PR TITLE
fix: Add k3s release to renovate

### DIFF
--- a/provision/ansible/inventory/group_vars/kubernetes/k3s.yml
+++ b/provision/ansible/inventory/group_vars/kubernetes/k3s.yml
@@ -5,6 +5,7 @@
 #
 
 # (string) Use a specific version of k3s
+# renovate: datasource=github-releases depName=k3s-io/k3s
 k3s_release_version: "v1.23.3+k3s1"
 
 # (bool) Install using hard links rather than symbolic links.


### PR DESCRIPTION
This should allow to update the k3s version used to install automatically.

v1.23.5+k3s1 is released, so if it works we should see a PR coming for that.