### PR TITLE
chore: add guide for configuring SSH key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 
 📍 Nodes are not security hardened by default, you can do this with [dev-sec/ansible-collection-hardening](https://github.com/dev-sec/ansible-collection-hardening) or something similar.
 
-1. Ensure you are able to SSH into you nodes from your workstation with using your private ssh key. This is how Ansible is able to connect to your remote nodes.
+1. Ensure you are able to SSH into you nodes from your workstation with using your private ssh key. This is how Ansible is able to connect to your remote nodes. [How to configure SSH key-based authentication](https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server)
 
 2. Install the deps by running `task ansible:deps`
 


### PR DESCRIPTION
**Description of the change**

The first step in the Ansible part of the guide mentions you should ensure you are able to SSH into your nodes from your workstation using your private SSH key. I simply added a link to a guide that describes how to generate a ssh key, add it to your server and disable password based logon.

**Benefits**

Easy reference / cheatsheet for those unfamiliar with the setup process.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A
