### PR TITLE
fix(cloudflare): min TLS version 1.0 -> 1.2

### DIFF
--- a/provision/terraform/cloudflare/main.tf
+++ b/provision/terraform/cloudflare/main.tf
@@ -38,7 +38,7 @@ resource "cloudflare_zone_settings_override" "cloudflare_settings" {
     ssl = "strict"
     # /ssl-tls/edge-certificates
     always_use_https         = "on"
-    min_tls_version          = "1.0"
+    min_tls_version          = "1.2"
     opportunistic_encryption = "on"
     tls_1_3                  = "zrt"
     automatic_https_rewrites = "on"


### PR DESCRIPTION
**Description of the change**

Change the minimum TLS version from 1.0 to 1.2 on the Cloudflare side

**Benefits**

Improved security by dropping support for insecure / deprecated TLS versions

**Possible drawbacks**

None that I see currently, please correct me if I'm wrong

**Applicable issues**

N/A

**Additional information**

<https://www.venafi.com/blog/why-its-dangerous-use-outdated-tls-security-protocols>
<https://www.packetlabs.net/posts/tls-1-1-no-longer-secure/>
